### PR TITLE
add podnode command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+kuve
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Available Commands:
   help        Help about any command
   images      Returns a list of images deployed into namespace
   logs        Get logs from pods and containers in a given namespace
+  podnode     View which node a given pod is running onin a given namespace
   secrets     Base64 decode and view secrets from a given namespace
 ```
 

--- a/cmd/podnode.go
+++ b/cmd/podnode.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/gabrie30/kuve/colorlog"
+	"github.com/spf13/cobra"
+)
+
+// podnodeCmd represents the exec command
+var podnodeCmd = &cobra.Command{
+	Use:   "podnode [pod_name] [namespace]",
+	Short: "View which node a given pod in a given namespace is running on",
+	Long:  `View which node a given pod in a given namespace is running on`,
+	Run: func(cmd *cobra.Command, args []string) {
+		podNode(args[0], args[1])
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(podnodeCmd)
+}
+
+func podNode(pod string, namespace string) {
+	cmd := fmt.Sprintf("kubectl get pod/%s --namespace=%s -o custom-columns=NODE:.spec.nodeName --no-headers", pod, namespace)
+	f, _ := exec.Command("/bin/sh", "-c", cmd).Output()
+
+	nodeip := strings.Split(string(f), "\n")
+	nodeip = removeEmptyString(nodeip)
+
+	if len(nodeip) < 1 {
+		colorlog.Error(fmt.Sprintf("No node found for pod: %v in namespace: %s\n", pod, namespace))
+		colorlog.Info("Check that your context, pod name and namespace are correct")
+		return
+	}
+	colorlog.Success(fmt.Sprintf("Pod %s is on node %s", pod, strings.Join(nodeip, ", ")))
+	colorlog.SubtleInfo("------------------------------------------------ NODE DEBUG INFO ------------------------------------------------")
+
+	customstring := "-o=custom-columns=NAME:.metadata.name,INSTANCE-TYPE:.metadata.labels.'beta\\.kubernetes\\.io/instance-type',NODEPOOL:.metadata.labels.'cloud\\.google\\.com/gke-nodepool',INTERNAL-IP:'.status.addresses[0].address'"
+	ni := fmt.Sprintf("kubectl get node %s %s", strings.Join(nodeip, ", "), customstring)
+	do, _ := exec.Command("/bin/sh", "-c", ni).Output()
+	fmt.Printf("%s", do)
+}
+
+func removeEmptyString(s []string) []string {
+	retVal := []string{}
+	for _, item := range s {
+		if item != "" {
+			retVal = append(retVal, item)
+		}
+	}
+	return retVal
+}


### PR DESCRIPTION
This adds `podnode` command and updates the readme, also adds a .gitignore so I don't accidentally upload the binary.

<img width="856" alt="Screen Shot 2019-08-09 at 9 41 51 AM" src="https://user-images.githubusercontent.com/9538405/62796384-fd0aa880-ba8d-11e9-9b78-99d4abf11d71.png">

```
kuve podnode --help

View which node a given pod in a given namespace is running on

Usage:
  kuve podnode [pod_name] [namespace] [flags]

Flags:
  -h, --help   help for podnode

Global Flags:
      --config string   config file (default is $HOME/.kuve.yaml)
```